### PR TITLE
Fix delay

### DIFF
--- a/src/GuzzleRetryMiddleware.php
+++ b/src/GuzzleRetryMiddleware.php
@@ -287,7 +287,7 @@ class GuzzleRetryMiddleware
         }
 
         // Delay!
-        usleep(((int) $delayTimeout) * 1000000);
+        usleep((int) ($delayTimeout * 1e6));
 
         // Return
         return $this($request, $options);


### PR DESCRIPTION
This change fixes the issue where if a server returns a decimal Retry-After, for example sub-second delays, the client will not have to wait until the next full second to retry the request. The previous code would first round the delay to the nearest integer (integer type-cast) and THEN convert to microseconds. However to retain the decimal precision, we should first convert to microseconds and THEN cast to an integer.
